### PR TITLE
Safety and pdf add

### DIFF
--- a/Weekly Comic Automate/move_weekly_to_converted.py
+++ b/Weekly Comic Automate/move_weekly_to_converted.py
@@ -1,14 +1,24 @@
 import os
 import shutil
 
-source_folder = r"Source_location"
-destination_folder = r"Destination"
+source_folder = r"Source"
+destination_folder = r"destination"
 
 for root, _, files in os.walk(source_folder):
     for file in files:
-        if file.endswith('.cbr') or file.endswith('.cbz'):
+        if file.endswith('.cbr') or file.endswith('.cbz') or file.endswith('.pdf'):
             source_file_path = os.path.join(root, file)
             destination_file_path = os.path.join(destination_folder, file)
             shutil.move(source_file_path, destination_file_path)
 
-print("All .cbr and .cbz files have been moved to the destination folder.")
+    # Check if the folder is empty after moving files
+    remaining_files = [f for f in os.listdir(root) if f.endswith('.cbr') or f.endswith('.cbz') or f.endswith('.pdf')]
+    if not remaining_files:
+        # Remove the empty folder
+        try:
+            os.rmdir(root)
+            print(f"Deleted empty folder: {root}")
+        except OSError as e:
+            print(f"Error deleting folder {root}: {e}")
+
+print("All .cbr, .cbz, and .pdf files have been moved to the destination folder.")


### PR DESCRIPTION
This script now moves PDF files along with CBR and CBZ files. It also deletes the leftover folder after checking that there are no CBR, CBZ, or PDF files left.