### PR TITLE
Fixed failed to move

### DIFF
--- a/Weekly Comic Automate/MTN2.1
+++ b/Weekly Comic Automate/MTN2.1
@@ -27,14 +27,23 @@ def main():
                 os.makedirs(dest_dir)
                 print(f'Created new folder: {dest_dir}')
 
+            successful_moves = 0
+            total_files = len(os.listdir(src_dir))
+
             for subdir, subdirs, subfiles in os.walk(src_dir):
                 for file in subfiles:
                     src_file = os.path.join(subdir, file)
                     dest_file = os.path.join(dest_dir, file)
-                    shutil.move(src_file, dest_file)
-                    print(f"Moved {src_file} to {dest_file}")
+                    
+                    try:
+                        shutil.move(src_file, dest_file)
+                        print(f"Moved {src_file} to {dest_file}")
+                        successful_moves += 1
+                    except Exception as e:
+                        print(f"Error: Failed to move {src_file} to {dest_file}")
+                        print(str(e))
 
-            if set(os.listdir(src_dir)) == set(os.listdir(dest_dir)):
+            if successful_moves == total_files:
                 shutil.rmtree(src_dir)
                 print(f"Deleted original folder: {src_dir}")
                 moved_folders.append(src_dir)


### PR DESCRIPTION
Added error handling: I added a try and except block around the shutil.move() function. This ensures that if an error occurs while moving a file, it will be caught and the error message will be printed, instead of causing the script to crash. This change doesn't necessarily cause the files to be moved successfully, but it helps to identify issues that might arise during the move process.

Implemented a counter to track successful file moves: Instead of comparing the contents of the source and destination folders directly, I added a counter (successful_moves) that increments for each successful file move. This counter is compared to the total number of files in the source folder (total_files). If the number of successful moves is equal to the total number of files, it means all files were moved successfully, and the source folder can be safely deleted.